### PR TITLE
Fix preparation of canary_path

### DIFF
--- a/libdropbox_fs_fix.c
+++ b/libdropbox_fs_fix.c
@@ -57,8 +57,8 @@ int statfs64(const char *path, struct statfs64 *buf) {
       char *dname = dirname(dup);
 
       canary_path = malloc(strlen(dname) + strlen(CANARY_FILE_PREFIX) + 1);
-      strncpy(canary_path, dname, strlen(dname) + 1);
-      strncat(canary_path, CANARY_FILE_PREFIX, strlen(CANARY_FILE_PREFIX));
+      strcpy(canary_path, dname);
+      strcat(canary_path, CANARY_FILE_PREFIX);
 
       free(dup);
 #ifdef DEBUG

--- a/libdropbox_fs_fix.c
+++ b/libdropbox_fs_fix.c
@@ -57,7 +57,7 @@ int statfs64(const char *path, struct statfs64 *buf) {
       char *dname = dirname(dup);
 
       canary_path = malloc(strlen(dname) + strlen(CANARY_FILE_PREFIX) + 1);
-      strncpy(canary_path, dname, strlen(dname));
+      strncpy(canary_path, dname, strlen(dname) + 1);
       strncat(canary_path, CANARY_FILE_PREFIX, strlen(CANARY_FILE_PREFIX));
 
       free(dup);

--- a/libdropbox_fs_fix.c
+++ b/libdropbox_fs_fix.c
@@ -56,9 +56,10 @@ int statfs64(const char *path, struct statfs64 *buf) {
       char *dup = strdup(path);
       char *dname = dirname(dup);
 
-      canary_path = malloc(strlen(dname) + strlen(CANARY_FILE_PREFIX) + 1);
-      strcpy(canary_path, dname);
-      strcat(canary_path, CANARY_FILE_PREFIX);
+      if (canary_path = malloc(strlen(dname) + strlen(CANARY_FILE_PREFIX) + 1)) {
+        strcpy(canary_path, dname);
+        strcat(canary_path, CANARY_FILE_PREFIX);
+      }
 
       free(dup);
 #ifdef DEBUG


### PR DESCRIPTION
Initialization of `canary_path` to `dname` + `CANARY_FILE_PREFIX` did not always work since the call to `strncpy()` did not set the terminating null byte.  This PR fixes this error and makes related small improvements.