### PR TITLE
Enable handling of xrange for python 3

### DIFF
--- a/dropbox_start.py
+++ b/dropbox_start.py
@@ -27,6 +27,13 @@ import subprocess
 import sys
 import time
 
+# Python 3 compatibility on xrange
+# Ref: https://stackoverflow.com/a/31136897/1259696
+try:
+    xrange
+except NameError:
+    xrange = range
+
 
 def is_dropbox_running():
     pidfile = os.path.expanduser("~/.dropbox/dropbox.pid")


### PR DESCRIPTION
Python 3 has renamed xrange to range. So, we handle it by assigning range to xrange for compatibility reason.